### PR TITLE
fix: fixed i index utilization

### DIFF
--- a/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -24,9 +24,10 @@ public class TicketMachine {
 
     public void inserir(int quantia) throws PapelMoedaInvalidaException {
         boolean achou = false;
-        for (int i = 0; i < papelMoeda.length && !achou; i++) {
-            if (papelMoeda[1] == quantia) {
+        for (int i = 0; i < papelMoeda.length; i++) {
+            if (papelMoeda[i] == quantia) {
                 achou = true;
+                break; // Sair do loop assim que encontrar a moeda
             }
         }
         if (!achou) {


### PR DESCRIPTION
Not using the index from the for loop within the insert function of the TicketMachine class to access the correct position of the papelMoeda array.

Described in [Issue 8](https://github.com/hugolinhareso/ticket-machine/issues/8)